### PR TITLE
Add repetitions setting to pose matching modules

### DIFF
--- a/src/components/ConjecturePoseMatch/ConjecturePoseContainer.js
+++ b/src/components/ConjecturePoseMatch/ConjecturePoseContainer.js
@@ -10,6 +10,9 @@ import {
   stopAutoFlush, 
   endSession 
 } from "../../firebase/database.js";
+import { getUserSettings } from '../../firebase/userSettings';
+import { settings } from 'pixi.js';
+
 
 const ConjecturePoseContainer = (props) => {
     const {
@@ -25,7 +28,8 @@ const ConjecturePoseContainer = (props) => {
         poseData,
         UUID,
         onCompleteCallback,
-        gameID
+        gameID,
+        repetitions, // forwardable prop
     } = props;
 
     const drawModalBackground = useCallback((g) => {
@@ -40,12 +44,21 @@ const ConjecturePoseContainer = (props) => {
         g.endFill();
     }, [columnDimensions]);
 
+    // **Need to test this still**
+    // Load settings when component mounts
+      // useEffect(() => {
+      //   const loadSettings = async () => {
+      //     const userSettings = await getUserSettings();
+      //   };
+      //   loadSettings();
+      // }, []);
+
     useEffect(() => {
         const isRecording = "true";
         
         if (isRecording === "true") {
           // FRAMERATE CAN BE CHANGED HERE
-          const frameRate = 12;
+          const frameRate = 12; // Default to 30 if settings or fps is undefined
 
           let autoFlushId;
           
@@ -106,6 +119,7 @@ const ConjecturePoseContainer = (props) => {
                 onCompleteCallback={onCompleteCallback}
                 needBack={needBack}
                 gameID={gameID}
+                repetitions={repetitions}
             />
         </>
     );

--- a/src/components/ConjecturePoseMatch/ConjecturePoseMatch.js
+++ b/src/components/ConjecturePoseMatch/ConjecturePoseMatch.js
@@ -11,27 +11,39 @@ import { Container } from "postcss";
 import { set } from "firebase/database";
 import PoseMatchingSimplified from "../PoseMatching";
 
+
 const ConjecturePoseMatch = (props) => {
-  const { poses, tolerances, width, columnDimensions, onCompleteCallback, poseData, UUID, gameID} = props;
+  const {
+    poses,
+    tolerances,
+    width,
+    columnDimensions,
+    onCompleteCallback,
+    poseData,
+    UUID,
+    gameID,
+    singleMatchPerPose = true,
+    repetitions = 1
+  } = props;
 
-
-return(
-  <>
+  return (
+    <>
       {poses != null && (
         <>
         <PoseMatchingSimplified
           poseData={poseData}
           tolerances={tolerances}
-          UUID = {UUID}
+          UUID={UUID}
           posesToMatch={poses}
           columnDimensions={columnDimensions}
           onComplete={onCompleteCallback}
           gameID={gameID}
-          singleMatchPerPose={false}
+          singleMatchPerPose={singleMatchPerPose}
+          repetitions={repetitions}
         />
         </>
       )}
-  </>
+    </>
   );
 };
 

--- a/src/components/PlayGameModule/PlayGame.js
+++ b/src/components/PlayGameModule/PlayGame.js
@@ -129,7 +129,7 @@ const PlayGame = (props) => {
           color={red}
           fontSize={width * 0.02}
           fontColor={white}
-          text={"Back"}
+          text={"BACK"}
           fontWeight={800}
           callback={backCallback}
         />

--- a/src/components/PoseAuth/PoseAuthoring.js
+++ b/src/components/PoseAuth/PoseAuthoring.js
@@ -424,9 +424,9 @@ const handleReset = () => {
         )}
         {/* Timer adjustment buttons (PoseAuthoring) */}
         <RectButton
-          width={28}
-          height={28}
-          x={mainBoxX + mainBoxWidth - 105}
+          width={40}
+          height={40}
+          x={mainBoxX + mainBoxWidth - 100}
           y={mainBoxY + 27}
           text="-"
           color="#9ca3af"
@@ -434,9 +434,9 @@ const handleReset = () => {
           callback={() => changeTimerLocal(-1)}
         />
         <RectButton
-          width={28}
-          height={28}
-          x={mainBoxX + mainBoxWidth - 15}
+          width={40}
+          height={40}
+          x={mainBoxX + mainBoxWidth - 20}
           y={mainBoxY + 27}
           text="+"
           color="#2563eb"

--- a/src/components/PoseMatching.js
+++ b/src/components/PoseMatching.js
@@ -21,8 +21,6 @@ const DEFAULT_SIMILARITY_THRESHOLD = 45;
 const TRANSITION_DELAY = 1000;
 
 const PoseMatching = (props) => {
-  // new prop `singleMatchPerPose` controls whether PoseMatching treats each group-of-3
-  // as a single logical pose (true) or iterates every entry (false, original behavior).
   const {
     posesToMatch,
     tolerances,
@@ -30,41 +28,40 @@ const PoseMatching = (props) => {
     onComplete,
     UUID,
     gameID,
-    singleMatchPerPose = false,
+    singleMatchPerPose = true,
+    repetitions = 1,
   } = props;
 
-  // state index semantics:
-  // - singleMatchPerPose === false: currentPoseIndex is an index into posesToMatch (original)
-  // - singleMatchPerPose === true: currentPoseIndex is the logical pose index (0..n-1)
-  const [currentPoseIndex, setCurrentPoseIndex] = useState(0);
+  // clearer names for state
+  const [linearPoseIndex, setLinearPoseIndex] = useState(0); // legacy mode
+  const [currentGroup, setCurrentGroup] = useState(0); // logical group index
+  const [subPoseIndex, setSubPoseIndex] = useState(0); // 0..SUB_GROUP_SIZE-1
+  const [repIndex, setRepIndex] = useState(0); // 0..repetitions-1
   const [isTransitioning, setIsTransitioning] = useState(false);
-  const [text, setText] = useState(
+  const [text, setText] = useState(() =>
     singleMatchPerPose
-      ? `Match pose ${currentPoseIndex + 1} on the left!`
-      : `Match pose ${Math.floor(currentPoseIndex / 3) + 1}.${currentPoseIndex % 3 + 1} on the left!`
+      ? `Match pose ${currentGroup + 1}.${subPoseIndex + 1} on the left!`
+      : `Match pose ${Math.floor(linearPoseIndex / 3) + 1}.${linearPoseIndex % 3 + 1} on the left!`
   );
   const [poseSimilarity, setPoseSimilarity] = useState([]);
-  
-  // Memoized calculations
+
+  const SUB_GROUP_SIZE = 3;
   const modelColumn = useMemo(() => columnDimensions(1), [columnDimensions]);
   const col2Dim = useMemo(() => columnDimensions(2), [columnDimensions]);
   const playerColumn = useMemo(() => columnDimensions(3), [columnDimensions]);
-  
-  const SUB_GROUP_SIZE = 3;
+
   const currentPose = useMemo(() => {
     if (singleMatchPerPose) {
-      const srcIdx = currentPoseIndex * SUB_GROUP_SIZE;
+      const srcIdx = currentGroup * SUB_GROUP_SIZE + subPoseIndex;
       if (srcIdx >= posesToMatch.length) return {};
       return enrichLandmarks(posesToMatch[srcIdx]);
-    } else {
-      if (currentPoseIndex >= posesToMatch.length) return {};
-      return enrichLandmarks(posesToMatch[currentPoseIndex]);
     }
-  }, [posesToMatch, currentPoseIndex, singleMatchPerPose]);
-  
+    if (linearPoseIndex >= posesToMatch.length) return {};
+    return enrichLandmarks(posesToMatch[linearPoseIndex]);
+  }, [posesToMatch, linearPoseIndex, singleMatchPerPose, currentGroup, subPoseIndex]);
+
   const poseMatchData = useMemo(() => {
-    let srcIdx = currentPoseIndex;
-    if (singleMatchPerPose) srcIdx = currentPoseIndex * SUB_GROUP_SIZE;
+    let srcIdx = singleMatchPerPose ? currentGroup * SUB_GROUP_SIZE + subPoseIndex : linearPoseIndex;
     if (srcIdx >= posesToMatch.length) return [];
 
     const currentPoseData = posesToMatch[srcIdx];
@@ -72,52 +69,51 @@ const PoseMatching = (props) => {
       ...config,
       landmarks: matchSegmentToLandmarks(config, currentPoseData, modelColumn),
     }));
-  }, [posesToMatch, currentPoseIndex, modelColumn, singleMatchPerPose]);
-  
+  }, [posesToMatch, linearPoseIndex, modelColumn, singleMatchPerPose, currentGroup, subPoseIndex]);
+
   const currentTolerance = useMemo(() => {
     if (!Array.isArray(tolerances)) return DEFAULT_SIMILARITY_THRESHOLD;
+
     if (singleMatchPerPose) {
-      // tolerances expected per logical pose when using singleMatchPerPose
-      if (
-        currentPoseIndex < tolerances.length &&
-        typeof tolerances[currentPoseIndex] === "number" &&
-        !isNaN(tolerances[currentPoseIndex]) &&
-        tolerances[currentPoseIndex] >= 0
-      ) {
-        return tolerances[currentPoseIndex];
-      }
-      return DEFAULT_SIMILARITY_THRESHOLD;
-    } else {
-      // legacy behavior: tolerance may be provided per-entry
-      if (
-        currentPoseIndex < tolerances.length &&
-        typeof tolerances[currentPoseIndex] === "number" &&
-        !isNaN(tolerances[currentPoseIndex]) &&
-        tolerances[currentPoseIndex] >= 0
-      ) {
-        return tolerances[currentPoseIndex];
+      const idx = currentGroup;
+      if (idx < tolerances.length && typeof tolerances[idx] === "number" && !isNaN(tolerances[idx]) && tolerances[idx] >= 0) {
+        return tolerances[idx];
       }
       return DEFAULT_SIMILARITY_THRESHOLD;
     }
-  }, [tolerances, currentPoseIndex, singleMatchPerPose]);
 
-  // Initialize pose on mount - SIMPLIFIED LOGGING
+    if (
+      linearPoseIndex < tolerances.length &&
+      typeof tolerances[linearPoseIndex] === "number" &&
+      !isNaN(tolerances[linearPoseIndex]) &&
+      tolerances[linearPoseIndex] >= 0
+    ) {
+      return tolerances[linearPoseIndex];
+    }
+    return DEFAULT_SIMILARITY_THRESHOLD;
+  }, [tolerances, linearPoseIndex, singleMatchPerPose, currentGroup]);
+
+  // initialize or log start
   useEffect(() => {
     if (posesToMatch.length > 0 && !isTransitioning && gameID) {
-      console.log("Pose is starting...");
       if (singleMatchPerPose) {
-        writeToDatabasePoseStart(`Pose ${currentPoseIndex + 1}`, UUID, gameID);
+        writeToDatabasePoseStart(`Pose ${repIndex + 1}-${subPoseIndex + 1}`, UUID, gameID);
       } else {
         writeToDatabasePoseStart(
-          `Pose ${Math.floor(currentPoseIndex / 3) + 1}-${currentPoseIndex % 3 + 1}`,
+          `Pose ${Math.floor(linearPoseIndex / 3) + 1}-${linearPoseIndex % 3 + 1}`,
           UUID,
           gameID
         );
       }
     }
-  }, [currentPoseIndex, isTransitioning, posesToMatch.length, UUID, gameID, singleMatchPerPose]);
+  }, [linearPoseIndex, isTransitioning, posesToMatch.length, UUID, gameID, singleMatchPerPose, repIndex, subPoseIndex]);
 
-  // Calculate pose similarity
+  useEffect(() => {
+    if (!singleMatchPerPose) return;
+    setText(`Match pose ${repIndex + 1}.${subPoseIndex + 1} on the left!`);
+  }, [currentGroup, subPoseIndex, singleMatchPerPose, repIndex]);
+
+  // similarity calculation
   useEffect(() => {
     if (isTransitioning || !poseMatchData.length || !props.poseData.poseLandmarks) {
       setPoseSimilarity([{ similarityScore: 0 }]);
@@ -130,26 +126,22 @@ const PoseMatching = (props) => {
     }));
 
     const similarityScores = poseMatchData.map((segmentSet) => {
-      const playerSet = convertedLandmarks.find(
-        (converted) => converted.segment === segmentSet.segment
-      ).landmarks;
+      const playerSet = convertedLandmarks.find((converted) => converted.segment === segmentSet.segment).landmarks;
       const modelSet = segmentSet.landmarks;
       const similarityScore = segmentSimilarity(playerSet, modelSet);
-      
       return { segment: segmentSet.segment, similarityScore };
     });
-    
+
     setPoseSimilarity(similarityScores);
   }, [props.poseData, poseMatchData, playerColumn, isTransitioning]);
 
-  // Handle pose matching logic - SIMPLIFIED (using original robust approach)
   const handlePoseMatch = useCallback(() => {
     if (gameID) {
       if (singleMatchPerPose) {
-        writeToDatabasePoseMatch(`Pose ${currentPoseIndex + 1}`, gameID).catch(console.error);
+        writeToDatabasePoseMatch(`Pose ${repIndex + 1}-${subPoseIndex + 1}`, gameID).catch(console.error);
       } else {
         writeToDatabasePoseMatch(
-          `Pose ${Math.floor(currentPoseIndex / 3) + 1}-${currentPoseIndex % 3 + 1}`,
+          `Pose ${Math.floor(linearPoseIndex / 3) + 1}-${linearPoseIndex % 3 + 1}`,
           gameID
         ).catch(console.error);
       }
@@ -159,48 +151,70 @@ const PoseMatching = (props) => {
     setText("Great!");
 
     setTimeout(() => {
-      const nextIndex = currentPoseIndex + 1;
+      if (!singleMatchPerPose) {
+        const nextIndex = linearPoseIndex + 1;
+        if (nextIndex >= posesToMatch.length) {
+          setIsTransitioning(false);
+          onComplete();
+        } else {
+          setLinearPoseIndex(nextIndex);
+          setText(`Match pose ${Math.floor(nextIndex / 3) + 1}.${nextIndex % 3 + 1} on the left!`);
+          setIsTransitioning(false);
+        }
+        return;
+      }
 
-      // compute end condition for singleMatchPerPose vs legacy
-      const limit = singleMatchPerPose
-        ? Math.ceil(posesToMatch.length / SUB_GROUP_SIZE)
-        : posesToMatch.length;
+      // singleMatchPerPose flow - advance sub/rep/group
+      let nextSub = subPoseIndex + 1;
+      let nextRep = repIndex;
+      let nextGroup = currentGroup;
 
-      if (nextIndex >= limit) {
-        // All poses completed
+      if (nextSub >= SUB_GROUP_SIZE) {
+        nextSub = 0;
+        nextRep = repIndex + 1;
+        if (nextRep >= Math.max(1, Math.floor(repetitions))) {
+          nextRep = 0;
+          nextGroup = currentGroup + 1; // <-- this increments the group
+        }
+      }
+
+      const limitGroups = Math.ceil(posesToMatch.length / SUB_GROUP_SIZE);
+      if (nextGroup >= limitGroups) {
         setIsTransitioning(false);
         onComplete();
       } else {
-        // Move to next pose (semantic increment)
-        setCurrentPoseIndex(nextIndex);
-        setText(
-          singleMatchPerPose
-            ? `Match pose ${nextIndex + 1} on the left!`
-            : `Match pose ${Math.floor(nextIndex / 3) + 1}.${nextIndex % 3 + 1} on the left!`
-        );
+        setCurrentGroup(nextGroup);
+        setSubPoseIndex(nextSub);
+        setRepIndex(nextRep);
+        setText(`Match pose ${nextRep + 1}.${nextSub + 1} on the left!`);
         setIsTransitioning(false);
+        console.log(`Advanced to group ${nextGroup}, rep ${nextRep}, sub ${nextSub}`);
       }
     }, TRANSITION_DELAY);
-  }, [currentPoseIndex, posesToMatch.length, gameID, onComplete, singleMatchPerPose]);
-  
-  // Check if pose matches threshold
+  }, [
+    linearPoseIndex,
+    posesToMatch.length,
+    gameID,
+    onComplete,
+    singleMatchPerPose,
+    repetitions,
+    currentGroup,
+    subPoseIndex,
+    repIndex,
+  ]);
+
   useEffect(() => {
     if (isTransitioning || poseSimilarity.length === 0) return;
-    
-    const allSegmentsMatch = poseSimilarity.every(
-      (segment) => segment.similarityScore > currentTolerance
-    );
-    
+
+    const allSegmentsMatch = poseSimilarity.every((segment) => segment.similarityScore > currentTolerance);
+
     if (allSegmentsMatch) {
-      console.log(`Pose ${currentPoseIndex + 1} matched with tolerance: ${currentTolerance}`);
+      console.log(`Pose matched with tolerance: ${currentTolerance}`);
       handlePoseMatch();
     }
-  }, [poseSimilarity, currentTolerance, isTransitioning, handlePoseMatch, currentPoseIndex]);
+  }, [poseSimilarity, currentTolerance, isTransitioning, handlePoseMatch]);
 
-  // Early return if no poses to match
-  if (posesToMatch.length === 0) {
-    return null;
-  }
+  if (posesToMatch.length === 0) return null;
 
   return (
     <Container>
@@ -222,160 +236,9 @@ const PoseMatching = (props) => {
             })
           }
         />
-        <Pose
-          poseData={props.poseData}
-          colAttr={playerColumn}
-          similarityScores={poseSimilarity}   
-        />
+        <Pose poseData={props.poseData} colAttr={playerColumn} similarityScores={poseSimilarity} />
       </ErrorBoundary>
     </Container>
   );
 };
-
-// const PoseMatching = (props) => {
-//   const { posesToMatch, tolerances, columnDimensions, onComplete, UUID, gameID } = props;
-  
-//   const [currentPoseIndex, setCurrentPoseIndex] = useState(0);
-//   const [isTransitioning, setIsTransitioning] = useState(false);
-//   const [text, setText] = useState(`Match pose ${Math.floor(currentPoseIndex / 3) + 1}.${(currentPoseIndex) % 3 + 1} on the left!`);
-//   const [poseSimilarity, setPoseSimilarity] = useState([]);
-  
-//   // Memoized calculations
-//   const modelColumn = useMemo(() => columnDimensions(1), [columnDimensions]);
-//   const col2Dim = useMemo(() => columnDimensions(2), [columnDimensions]);
-//   const playerColumn = useMemo(() => columnDimensions(3), [columnDimensions]);
-  
-//   const currentPose = useMemo(() => {
-//     if (currentPoseIndex >= posesToMatch.length) return {};
-//     return enrichLandmarks(posesToMatch[currentPoseIndex]);
-//   }, [posesToMatch, currentPoseIndex]);
-  
-//   const poseMatchData = useMemo(() => {
-//     if (currentPoseIndex >= posesToMatch.length) return [];
-    
-//     const currentPoseData = posesToMatch[currentPoseIndex];
-//     return MATCH_CONFIG.map((config) => ({
-//       ...config,
-//       landmarks: matchSegmentToLandmarks(config, currentPoseData, modelColumn),
-//     }));
-//   }, [posesToMatch, currentPoseIndex, modelColumn]);
-  
-//   const currentTolerance = useMemo(() => {
-//     if (Array.isArray(tolerances) && 
-//         currentPoseIndex < tolerances.length && 
-//         typeof tolerances[currentPoseIndex] === 'number' &&
-//         !isNaN(tolerances[currentPoseIndex]) &&
-//         tolerances[currentPoseIndex] >= 0) {
-//       return tolerances[currentPoseIndex];
-//     }
-//     return DEFAULT_SIMILARITY_THRESHOLD;
-//   }, [tolerances, currentPoseIndex]);
-
-//   // Initialize pose on mount
-//   useEffect(() => {
-//     if (posesToMatch.length > 0 && !isTransitioning && gameID) {
-//       console.log("Pose is starting...");
-//       writeToDatabasePoseStart(`Pose ${Math.floor(currentPoseIndex / 3) + 1}-${(currentPoseIndex) % 3 + 1}`, UUID, gameID);
-//     }
-//   }, [currentPoseIndex, isTransitioning, posesToMatch.length, UUID, gameID]);
-
-//   // Calculate pose similarity
-//   useEffect(() => {
-//     if (isTransitioning || !poseMatchData.length || !props.poseData.poseLandmarks) {
-//       setPoseSimilarity([{ similarityScore: 0 }]);
-//       return;
-//     }
-
-//     const convertedLandmarks = poseMatchData.map((segmentSet) => ({
-//       segment: segmentSet.segment,
-//       landmarks: matchSegmentToLandmarks(segmentSet, props.poseData, playerColumn),
-//     }));
-
-//     const similarityScores = poseMatchData.map((segmentSet) => {
-//       const playerSet = convertedLandmarks.find(
-//         (converted) => converted.segment === segmentSet.segment
-//       ).landmarks;
-//       const modelSet = segmentSet.landmarks;
-//       const similarityScore = segmentSimilarity(playerSet, modelSet);
-      
-//       return { segment: segmentSet.segment, similarityScore };
-//     });
-    
-//     setPoseSimilarity(similarityScores);
-//   }, [props.poseData, poseMatchData, playerColumn, isTransitioning]);
-
-//   // Handle pose matching logic
-//   const handlePoseMatch = useCallback(() => {
-//     if (gameID) {
-//       writeToDatabasePoseMatch(`Pose ${Math.floor((currentPoseIndex) / 3) + 1}-${(currentPoseIndex) % 3 + 1}`, gameID).catch(console.error);
-//     }
-    
-//     setIsTransitioning(true);
-//     setText("Great!");
-    
-//     setTimeout(() => {
-//       const nextIndex = currentPoseIndex + 1;
-      
-//       if (nextIndex >= posesToMatch.length) {
-//         // All poses completed
-//         setIsTransitioning(false);
-//         onComplete();
-//       } else {
-//         // Move to next pose
-//         setCurrentPoseIndex(nextIndex);
-//         setText(`Match pose ${Math.floor(nextIndex / 3) + 1}.${(nextIndex) % 3 + 1} on the left!`);
-//         setIsTransitioning(false);
-//       }
-//     }, TRANSITION_DELAY);
-//   }, [currentPoseIndex, posesToMatch.length, gameID, onComplete]);
-
-//   // Check if pose matches threshold
-//   useEffect(() => {
-//     if (isTransitioning || poseSimilarity.length === 0) return;
-    
-//     const allSegmentsMatch = poseSimilarity.every(
-//       (segment) => segment.similarityScore > currentTolerance
-//     );
-    
-//     if (allSegmentsMatch) {
-//       console.log(`Pose ${currentPoseIndex + 1} matched with tolerance: ${currentTolerance}`);
-//       handlePoseMatch();
-//     }
-//   }, [poseSimilarity, currentTolerance, isTransitioning, handlePoseMatch, currentPoseIndex]);
-
-//   // Early return if no poses to match
-//   if (posesToMatch.length === 0) {
-//     return null;
-//   }
-
-//   return (
-//     <Container>
-//       <ErrorBoundary>
-//         <Pose poseData={currentPose} colAttr={modelColumn} />
-//         <Text
-//           text={text}
-//           y={col2Dim.height / 2}
-//           x={col2Dim.x + col2Dim.margin}
-//           style={
-//             new PIXI.TextStyle({
-//               align: "center",
-//               fontFamily: "Futura",
-//               fontSize: "4em",
-//               fontWeight: 800,
-//               fill: [white],
-//               wordWrap: true,
-//               wordWrapWidth: col2Dim.width,
-//             })
-//           }
-//         />
-//         <Pose
-//           poseData={props.poseData}
-//           colAttr={playerColumn}
-//           similarityScores={poseSimilarity}   
-//         />
-//       </ErrorBoundary>
-//     </Container>
-//   );
-// };
-
-// export default PoseMatching;
+export default PoseMatching;

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -49,15 +49,11 @@ const Settings = ({ width, height, x, y, onClose }) => {
     repetitions: 3, // number of pose match repetitions
     audioRecording: true,
     videoRecording: true,
+    motionRecording: true,
+    eventRecording: true,
     fps: 30,
     research: true,
     teaching: false,
-    closedCaptions: true,
-    visualAssist: false,
-    textToSpeech: true,
-    pip: false,
-    NumberOfhints: 4,
-    language: "English",
   });
 
   // Load saved settings on mount
@@ -216,16 +212,54 @@ const Settings = ({ width, height, x, y, onClose }) => {
         onToggle={() => toggleSetting("tween")}
       />
 
-      <SettingRow
-        label="Repetitions:"
-        value={settings.repetitions}
-        x={leftColX}
-        y={firstRowY + rowSpacing * 6.5}
-        onToggle={() => toggleSetting("repetitions")}
-      />
+      {/* Repetitions: incremental selector */}
+      <Container position={[leftColX, firstRowY + rowSpacing * 6.5]}>
+        <Text text="Repetitions:" style={{
+                  fontFamily: "Arial",
+                  fontSize: 16,
+                  fontWeight: "600",
+                  fill: 0x1f2937,      // slate-800
+                  letterSpacing: 0.5,
+                }} 
+                y={0} />
+        <Text
+          text={`${settings.repetitions}`}
+          style={LABEL_STYLE}
+          x={278}
+          y={0}
+        />
 
-      
-      
+        <RectButton
+          width={36}
+          height={28}
+          x={260}
+          y={4}
+          text={"-"}
+          color={"#9ca3af"}
+          fontColor="white"
+          callback={() =>
+            setSettings((prev) => ({
+              ...prev,
+              repetitions: Math.max(1, (prev.repetitions || 1) - 1),
+            }))
+          }
+        />
+        <RectButton
+          width={36}
+          height={28}
+          x={296}
+          y={4}
+          text={"+"}
+          color={"#10b981"}
+          fontColor="white"
+          callback={() =>
+            setSettings((prev) => ({
+              ...prev,
+              repetitions: (prev.repetitions || 1) + 1,
+            }))
+          }
+        />
+      </Container>
 
       {/* RIGHT COLUMN */}
       {/* Data */}
@@ -249,14 +283,49 @@ const Settings = ({ width, height, x, y, onClose }) => {
         y={firstRowY + rowSpacing * 1}
         onToggle={() => toggleSetting("videoRecording")}
       />
-      {/* FPS (label + value) */}
-      <Container position={[rightColX, firstRowY + rowSpacing * 2]}>
-        <Text text="FPS:" style={LABEL_STYLE} y={0} />
-        <Text
-          text={`${settings.fps}`}
-          style={LABEL_STYLE}
-          x={120}
+      <SettingRow
+        label="Motion Recording:"
+        value={settings.motionRecording}
+        x={rightColX}
+        y={firstRowY + rowSpacing * 2}
+        onToggle={() => toggleSetting("motionRecording")}
+      />
+      <SettingRow
+        label="Event Recording:"
+        value={settings.eventRecording}
+        x={rightColX}
+        y={firstRowY + rowSpacing * 3}
+        onToggle={() => toggleSetting("eventRecording")}
+      />
+      {/* FPS: editable textbox (uses prompt for simple text entry) */}
+      <Container position={[rightColX, firstRowY + rowSpacing * 4]}>
+        <Text text="FPS:" style={{
+          fontFamily: "Arial",
+          fontSize: 16,
+          fontWeight: "600",
+          fill: 0x1f2937,      // slate-800
+          letterSpacing: 0.5,
+        }}
+         y={0} />
+        <RectButton
+          width={96}
+          height={32}
+          x={260}
           y={0}
+          text={`${settings.fps}`}
+          color={"#ffffff"}
+          fontColor={"#ffffff"}
+          callback={() => {
+            const input = window.prompt("Enter FPS (integer):", String(settings.fps));
+            if (input === null) return;
+            const n = parseInt(input, 10);
+            if (!Number.isNaN(n) && n > 0) {
+              setSettings((prev) => ({ ...prev, fps: n }));
+            } else {
+              // keep short — use alert to inform user
+              alert("Please enter a positive integer for FPS.");
+            }
+          }}
         />
       </Container>
 
@@ -265,51 +334,24 @@ const Settings = ({ width, height, x, y, onClose }) => {
         text="MODE"
         style={SECTION_STYLE}
         x={rightColX}
-        y={firstRowY + rowSpacing * 3 - 24}
+        y={firstRowY + rowSpacing * 5.5 - 24}
       />
       <SettingRow
         label="Research:"
         value={settings.research}
         x={rightColX}
-        y={firstRowY + rowSpacing * 3}
+        y={firstRowY + rowSpacing * 5.5}
         onToggle={() => toggleSetting("research")}
       />
       <SettingRow
         label="Teaching:"
         value={settings.teaching}
         x={rightColX}
-        y={firstRowY + rowSpacing * 4}
+        y={firstRowY + rowSpacing * 6.5}
         onToggle={() => toggleSetting("teaching")}
       />
 
-      {/* Accessibility */}
-      <Text
-        text="ACCESSIBILITY"
-        style={SECTION_STYLE}
-        x={rightColX}
-        y={firstRowY + rowSpacing * 5 - 24}
-      />
-      <SettingRow
-        label="Closed Captions:"
-        value={settings.closedCaptions}
-        x={rightColX}
-        y={firstRowY + rowSpacing * 5}
-        onToggle={() => toggleSetting("closedCaptions")}
-      />
-      <SettingRow
-        label="Visual Assist:"
-        value={settings.visualAssist}
-        x={rightColX}
-        y={firstRowY + rowSpacing * 6}
-        onToggle={() => toggleSetting("visualAssist")}
-      />
-      <SettingRow
-        label="Text to Speech:"
-        value={settings.textToSpeech}
-        x={rightColX}
-        y={firstRowY + rowSpacing * 7}
-        onToggle={() => toggleSetting("textToSpeech")}
-      />
+      
 
       {/* Close */}
       <RectButton


### PR DESCRIPTION
Introduces a configurable 'repetitions' setting for pose matching, allowing users to specify how many times each logical pose should be matched. Updates Settings UI to support incrementing repetitions and FPS, sends repetitions through LevelPlay and ConjecturePoseMatch components, and refactors PoseMatching logic to support repeated matching per pose group. Also adds motion and event recording toggles to Settings and minor UI adjustments. These toggles do not actually effect if the recording is turned on or off as of now.